### PR TITLE
feature: Add '?pad' option

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,13 +2,21 @@ import React from 'react'
 import * as validHexColor from 'valid-hex-color'
 import palettes from 'nice-color-palettes'
 
-function whatTimeIsIt() {
+function whatTimeIsIt(props: IProps) {
   const now = new Date()
 
-  let time = {
-    hours: now.getHours().toString().padStart(2, '0'),
-    minutes: now.getMinutes().toString().padStart(2, '0'),
-    seconds: now.getSeconds().toString().padStart(2, '0'),
+  let hours = now.getHours()
+  let minutes = now.getMinutes()
+  let seconds = now.getSeconds()
+
+  if (props.format === 12) {
+    hours = hours % 12 || 12
+  }
+
+  let time: any = {
+    hours: hours.toString().padStart(props.pad ? 2 : 1, '0'),
+    minutes: minutes.toString().padStart(2, '0'),
+    seconds: seconds.toString().padStart(2, '0'),
   }
 
   return time
@@ -36,6 +44,7 @@ interface IProps {
   blink: boolean
   position: Position
   format: 12 | 24
+  pad: boolean
 }
 
 interface IState {
@@ -102,6 +111,7 @@ export default class extends React.Component<IProps, IState> {
       showLink: query.showLink != null,
       blink: query.blink != null,
       format: parseInt(query.format || '24'),
+      pad: query.pad != null,
     }
   }
 
@@ -119,7 +129,7 @@ export default class extends React.Component<IProps, IState> {
   }
 
   tick() {
-    let time = whatTimeIsIt()
+    let time = whatTimeIsIt(this.props)
     this.setState({ ...time })
   }
 
@@ -177,11 +187,6 @@ export default class extends React.Component<IProps, IState> {
     }
 
     const flexPositions = this.getFlexPositions()
-    let hours = parseInt(this.state.hours) || 0
-
-    if (this.props.format === 12) {
-      hours = hours < 12 ? hours : hours - 12
-    }
 
     return (
       <>
@@ -194,7 +199,7 @@ export default class extends React.Component<IProps, IState> {
           }
         >
           <div id="time">
-            <span id="hours">{hours}</span>
+            <span id="hours">{this.state.hours}</span>
             <span className="colon" style={{ opacity: colonOpacity }}>
               :
             </span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,17 +6,9 @@ function whatTimeIsIt() {
   const now = new Date()
 
   let time = {
-    hours: now.getHours().toString(),
-    minutes: now.getMinutes().toString(),
-    seconds: now.getSeconds().toString(),
-  }
-
-  if (time.seconds.length === 1) {
-    time.seconds = '0' + time.seconds
-  }
-
-  if (time.minutes.length === 1) {
-    time.minutes = '0' + time.minutes
+    hours: now.getHours().toString().padStart(2, '0'),
+    minutes: now.getMinutes().toString().padStart(2, '0'),
+    seconds: now.getSeconds().toString().padStart(2, '0'),
   }
 
   return time

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ Perfect if you use tools like [Plash](https://sindresorhus.com/plash).
   - [`?showLink`](https://time.pablopunk.com/?showLink)
 - `format=12`: Don't like military time? Shame on you. But you can use 12h format instead.
   - [`?format=12`](https://time.pablopunk.com/?format=12)
+- `pad`: Single digit hours will be padded with a 0: 9:41 will be shown as 09:41.
+  - [`?pad`](https://time.pablopunk.com/?pad)
 
 ## More Examples
 


### PR DESCRIPTION
Personally, I dislike the formatting inconsitency very much and would prefer `00:47:00` over `0:47:00`.

<img width="856" alt="image" src="https://user-images.githubusercontent.com/834636/127933016-2625ff30-54e8-4719-9603-134e0376ed20.png">
