### PR TITLE
Update accepted values for showLink

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -40,7 +40,7 @@ interface IProps {
   bg: string
   font: string
   fontSize: string
-  showLink: boolean
+  showLink: string
   blink: boolean
   position: Position
   format: 12 | 24
@@ -51,6 +51,8 @@ interface IState {
   hours: string
   minutes: string
   seconds: string
+  showLink: boolean
+  considerMouseInteraction: boolean
   mouseInteraction: boolean
   lastTickHadColon: boolean
   clearMouseTimeout?: ReturnType<typeof setTimeout>
@@ -109,7 +111,7 @@ export default class extends React.Component<IProps, IState> {
       ...query,
       seconds: query.seconds != null,
       randomColors: query.randomColors != null,
-      showLink: query.showLink != null,
+      showLink: query.showLink,
       blink: query.blink != null,
       format: parseInt(query.format || '24'),
       pad: query.pad != null,
@@ -119,12 +121,27 @@ export default class extends React.Component<IProps, IState> {
   constructor(props) {
     super(props)
 
+    let showLink: boolean
+    switch (this.props.showLink) {
+      case '':
+      case 'true':
+        showLink = true
+        break;
+      case 'false':
+        showLink = false
+        break
+      default:
+        showLink = undefined
+        break
+    }
+
     this.state = {
       hours: '',
       minutes: '',
       seconds: '',
-      mouseInteraction:
-        this.props.showLink == null ? false : this.props.showLink,
+      showLink: showLink,
+      considerMouseInteraction: showLink == undefined,
+      mouseInteraction: [undefined, true].includes(showLink),
       lastTickHadColon: false,
     }
   }
@@ -173,7 +190,8 @@ export default class extends React.Component<IProps, IState> {
   }
 
   mouseInteracting() {
-    const { mouseInteraction, clearMouseTimeout } = this.state
+    const { clearMouseTimeout, considerMouseInteraction } = this.state
+    if (!considerMouseInteraction) return
 
     if (clearMouseTimeout) {
       clearTimeout(clearMouseTimeout)
@@ -204,7 +222,9 @@ export default class extends React.Component<IProps, IState> {
     return (
       <>
         {mouseInteraction && (
-          <a href="https://github.com/pablopunk/time">Code available here</a>
+          <a href="https://github.com/pablopunk/time">
+            Code available here
+          </a>
         )}
         <main onMouseMove={() => this.mouseInteracting()}>
           <div id="time">

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Perfect if you use tools like [Plash](https://sindresorhus.com/plash).
   - [`?fontSize=200px`](https://time.pablopunk.com/?fontSize=200px)
 - `position`: Position on the screen. Defaults to center:
 
-  ```
+  ```txt
   top-left      top       top-right
   left                        right
   bottom-left  bottom  bottom-right
@@ -37,8 +37,9 @@ Perfect if you use tools like [Plash](https://sindresorhus.com/plash).
   - [`?randomColors`](https://time.pablopunk.com/?randomColors)
 - `blink`: The colon between the hours and the minutes will blink each second.
   - [`?blink`](https://time.pablopunk.com/?blink)
-- `showLink`: A link to this repo is shown automatically when mouse input is detected, but it can be forced using this option.
-  - [`?showLink`](https://time.pablopunk.com/?showLink)
+- `showLink`: By default, a link to this repo is shown when mouse input is detected, but it can be forced always on or off.
+  - On: [`?showLink`](https://time.pablopunk.com/?showLink) or [`?showLink=true`](https://time.pablopunk.com/?showLink=true)
+  - Off: [`?showLink=false`](https://time.pablopunk.com/?showLink=false)
 - `format=12`: Don't like military time? Shame on you. But you can use 12h format instead.
   - [`?format=12`](https://time.pablopunk.com/?format=12)
 - `pad`: Single digit hours will be padded with a 0: 9:41 will be shown as 09:41.


### PR DESCRIPTION
## Summary

- Updated logic behind `showLink` to accept booleans

## Notes

- Currently, the README seems to imply that [`?showLink`](https://time.pablopunk.com/?showLink) makes the link always present; I did not find that to be the case

- With this PR I'm proposing support for five (5) different states
  1. Condition: absence of `showLink`, Behavior: appears on mouse interaction
  1. Condition: `?showLink`, Behavior: always present
  1. Condition: `?showLink=true`, Behavior: always present
  1. Condition: `?showLink=false`, Behavior: never present
  1. Condition: `?showLink=anyotherstring`, Behavior: appears on mouse interaction